### PR TITLE
feat: add needed CORS to allow front-end with cloudfront domain to call API

### DIFF
--- a/api/response_maker.py
+++ b/api/response_maker.py
@@ -1,0 +1,14 @@
+import json
+
+
+def make_response(status_code=404, access_control_allow_origin=None, body=None):
+    return {
+        "statusCode": status_code,
+        "body": json.dumps(body),
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": access_control_allow_origin,
+            "Access-Control-Allow-Headers": "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token",
+            "Access-Control-Allow-Methods": "OPTIONS,GET,PUT,POST,DELETE",
+        },
+    }

--- a/api/upload/get.py
+++ b/api/upload/get.py
@@ -1,4 +1,7 @@
-import json
+import os
+from api.response_maker import make_response
+
+cloudfront_url = os.environ.get("CLOUDFRONT_URL")
 
 
 def handler(event, context):
@@ -17,14 +20,12 @@ def handler(event, context):
         },
     ]
 
-    # Prepare the response
-    response = {
+    # Prepare the body
+    body = {
         "message": "Retrieve PDF requirements successfully.",
         "header": pdf_requirements,
     }
 
-    return {
-        "statusCode": 200,
-        "body": json.dumps(response),
-        "headers": {"Content-Type": "application/json"},
-    }
+    return make_response(
+        status_code=200, access_control_allow_origin=cloudfront_url, body=body
+    )

--- a/api/upload/post.py
+++ b/api/upload/post.py
@@ -1,7 +1,11 @@
-import json
 import base64
+import os
 from io import BytesIO
 from pdfminer.high_level import extract_text
+from api.response_maker import make_response
+
+
+cloudfront_url = os.environ.get("CLOUDFRONT_URL")
 
 
 def handler(event, context):
@@ -14,14 +18,12 @@ def handler(event, context):
     # Use pdfminer.six to extract text from the PDF
     text = extract_text(BytesIO(pdf_content))
 
-    # Prepare the response
-    response = {"message": "PDF processed successfully.", "content": text}
+    # Prepare the body
+    body = {"message": "PDF processed successfully.", "content": text}
 
-    return {
-        "statusCode": 200,
-        "body": json.dumps(response),
-        "headers": {"Content-Type": "application/json"},
-    }
+    return make_response(
+        status_code=200, access_control_allow_origin=cloudfront_url, body=body
+    )
 
 
 def ensure_base64_padding(encoded_str):

--- a/tests/test_response_maker.py
+++ b/tests/test_response_maker.py
@@ -1,0 +1,22 @@
+import json
+from unittest.mock import patch
+from api.response_maker import make_response
+
+def test_make_response():
+    status_code = 200
+    access_control_allow_origin = "domain.cloudfront.net"
+    body = "hello world"
+    expected_response = {
+        "statusCode": status_code,
+        "body": json.dumps(body),
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": access_control_allow_origin,
+            "Access-Control-Allow-Headers": "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token",
+            "Access-Control-Allow-Methods": "OPTIONS,GET,PUT,POST,DELETE"
+            },
+    }
+    
+    response = make_response(status_code=200, access_control_allow_origin=access_control_allow_origin, body=body)
+    
+    assert response == expected_response


### PR DESCRIPTION
## [make response helper function](https://github.com/mnsavage/pdf_parser_back_end/pull/11/commits/0e5faaa897ae8815d7a8b13153cd47e58f97c44d):
- this helper functions is used to help create API responses

## [CORS](https://github.com/mnsavage/pdf_parser_back_end/pull/11/commits/4f94c971bb86b99aa68a7713cf8d101d52785e9a):
- get the cloudfront url that is randomly generated (note: it is free due to being randomly generated) so then we can make a response with the needed headers to allow front-end using the cloudfront url to call API